### PR TITLE
Case insensitive names & ability to remove a release

### DIFF
--- a/bin/maintenance/plugins-table-plugin-collation.js
+++ b/bin/maintenance/plugins-table-plugin-collation.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+var db,
+	pluginsDb = require( "../../lib/pluginsdb" );
+
+function runQueries( queries, fn ) {
+	db.run( queries.shift(), function( error ) {
+		if ( error ) {
+			return fn( error );
+		}
+
+		if ( !queries.length ) {
+			return fn( null );
+		}
+
+		runQueries( queries, fn );
+	});
+}
+
+db = pluginsDb.connect(function( error ) {
+	if ( error ) {
+		console.log( "Error connecting to the database." );
+		console.log( error );
+		process.exit( 1 );
+	}
+
+	runQueries([
+		"BEGIN TRANSACTION",
+		"CREATE TEMPORARY TABLE plugins_backup(" +
+			"plugin TEXT PRIMARY KEY, " +
+			"owner TEXT, " +
+			"repo TEXT, " +
+			"watchers INTEGER DEFAULT 0, " +
+			"forks INTEGER DEFAULT 0" +
+		")",
+		"INSERT INTO plugins_backup SELECT * FROM plugins",
+		"DROP TABLE plugins",
+		"CREATE TABLE plugins (" +
+			"plugin TEXT PRIMARY KEY COLLATE NOCASE, " +
+			"owner TEXT, " +
+			"repo TEXT, " +
+			"watchers INTEGER DEFAULT 0, " +
+			"forks INTEGER DEFAULT 0" +
+		")",
+		"INSERT INTO plugins SELECT * FROM plugins_backup",
+		"DROP TABLE plugins_backup",
+		"COMMIT"
+	], function( error ) {
+		if ( error ) {
+			console.log( "Error updating table." );
+			console.log( error );
+			process.exit( 1 );
+		}
+
+		console.log( "Successfully updated table." );
+	});
+});

--- a/bin/remove-release.js
+++ b/bin/remove-release.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+var Step = require( "step" ),
+	pluginsDb = require( "../lib/pluginsdb" ),
+	wordpress = require( "../lib/wordpress" );
+
+process.stdin.setEncoding( "utf8" );
+
+function prompt( message, fn ) {
+	process.stdout.write( message + " " );
+	process.stdin.resume();
+
+	process.stdin.once( "data", function( chunk ) {
+		process.stdin.pause();
+		fn( null, chunk.trim() );
+	});
+}
+
+function showError( error ) {
+	console.log( "Error removing release" );
+	console.log( error.stack );
+	process.exit( 1 );
+}
+
+function removeRelease() {
+	var plugin, version;
+
+	Step(
+		function() {
+
+			// Find out which plugin to remove
+			prompt( "Plugin:", this );
+		},
+
+		function( error, _plugin ) {
+			if ( error ) {
+				return showError( error );
+			}
+
+			plugin = _plugin;
+
+			// Find out which version
+			prompt( "Version:", this );
+		},
+
+		function( error, _version ) {
+			if ( error ) {
+				return showError( error );
+			}
+
+			version = _version;
+
+			// Verify the release exists in WordPress
+			wordpress.getPostForRelease( plugin, version, this );
+		},
+
+		function( error, post ) {
+			if ( error ) {
+				return showError( error );
+			}
+
+			if ( !post.id ) {
+				console.log( plugin + " " + version + " does not exist in WordPress." );
+				process.exit( 1 );
+			}
+
+			// Track the removal
+			pluginsDb.removeRelease({
+				plugin: plugin,
+				version: version,
+				postId: post.id
+			}, this );
+		},
+
+		function( error ) {
+			if ( error ) {
+				return showError( error );
+			}
+
+			console.log( "Removal of " + plugin + " " + version + " has been queued." );
+		}
+	);
+}
+
+removeRelease();

--- a/lib/pluginsdb.js
+++ b/lib/pluginsdb.js
@@ -113,6 +113,13 @@ var pluginsDb = module.exports = {
 			});
 	}),
 
+	removeRelease: auto(function( data, fn ) {
+		data = JSON.stringify( data );
+
+		db.run( "INSERT INTO actions( action, data ) VALUES( ?, ? )",
+			[ "removeRelease", data ], fn );
+	}),
+
 	updateRepoMeta: auto(function( repo, data, fn ) {
 		db.run( "UPDATE plugins SET watchers = ?, forks = ? " +
 			"WHERE repo = ?",

--- a/lib/pluginsdb.js
+++ b/lib/pluginsdb.js
@@ -155,7 +155,7 @@ var pluginsDb = module.exports = {
 				}
 
 				db.run( "CREATE TABLE plugins (" +
-					"plugin TEXT PRIMARY KEY, " +
+					"plugin TEXT PRIMARY KEY COLLATE NOCASE, " +
 					"owner TEXT, " +
 					"repo TEXT, " +
 					"watchers INTEGER DEFAULT 0, " +

--- a/lib/pluginsdb.js
+++ b/lib/pluginsdb.js
@@ -5,6 +5,7 @@ var db;
 
 function connect( fn ) {
 	db = new sqlite.Database( config.pluginsDb, fn );
+	return db;
 }
 
 function auto( fn ) {
@@ -27,6 +28,8 @@ function auto( fn ) {
 }
 
 var pluginsDb = module.exports = {
+	connect: connect,
+
 	getOwner: auto(function( plugin, fn ) {
 		db.get( "SELECT owner FROM plugins WHERE plugin = ?",
 			[ plugin ], function( error, row ) {

--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -1,5 +1,10 @@
 var wordpress = require( "wordpress" ),
+	semver = require( "semver" ),
 	config = require( "./config" );
+
+function isStable( version ) {
+	return (/^\d+\.\d+\.\d+$/).test( version );
+}
 
 var client = wordpress.createClient( config.wordpress );
 
@@ -11,6 +16,93 @@ client.getPostForPlugin = function( plugin, fn ) {
 
 		fn( null, wordpress.fieldMap.from( post, "post" ) );
 	});
+};
+
+client.post = {
+	fromRelease: function( data, fn ) {
+		var repo = data.repo,
+			manifest = data.manifest,
+			tag = data.tag;
+
+		repo.getReleaseDate( tag, function( error, date ) {
+			if ( error ) {
+				return fn( error );
+			}
+
+			fn( null, {
+				type: "jquery_plugin",
+				status: "publish",
+				title: manifest.title,
+				content: manifest.description,
+				date: date,
+				termNames: {
+					post_tag: (manifest.keywords || []).map(function( keyword ) {
+						return keyword.toLowerCase();
+					})
+				},
+				customFields: [
+					{ key: "download_url", value: manifest.download || repo.downloadUrl( tag ) },
+					{ key: "repo_url", value: repo.siteUrl },
+					{ key: "manifest", value: JSON.stringify( manifest ) }
+				]
+			});
+		});
+	},
+
+	getVersions: function( page ) {
+		var versions = (page.customFields || []).filter(function( customField ) {
+			return customField.key === "versions";
+		});
+		return versions.length ? JSON.parse( versions[ 0 ].value ) : [];
+	},
+
+	addVersion: function( versions, newVersion ) {
+		var listed, latest;
+
+		listed = versions
+			.concat( newVersion )
+			.sort( semver.compare )
+			.reverse()
+			.filter(function( version ) {
+				if ( latest ) {
+					return isStable( version );
+				}
+				if ( isStable( version ) ) {
+					latest = version;
+				}
+				return true;
+			})
+			.reverse();
+
+		// No stable relases yet, show latest pre-release
+		if ( !latest ) {
+			latest = listed[ listed.length - 1 ];
+		}
+
+		return {
+			all: versions,
+			listed: listed,
+			latest: latest
+		};
+	},
+
+	mergeCustomFields: function( existing, current ) {
+		current.forEach(function( customField ) {
+
+			// If the field already exists, update the value
+			for ( var i = 0, length = existing.length - 1; i < length; i++ ) {
+				if ( existing[ i ].key === customField.key ) {
+					existing[ i ].value = customField.value;
+					return;
+				}
+			}
+
+			// The field doesn't exist, so add it
+			existing.push( customField );
+		});
+
+		return existing;
+	}
 };
 
 module.exports = client;

--- a/lib/wordpress.js
+++ b/lib/wordpress.js
@@ -18,6 +18,16 @@ client.getPostForPlugin = function( plugin, fn ) {
 	});
 };
 
+client.getPostForRelease = function( plugin, version, fn ) {
+	client.authenticatedCall( "jq-pjc.getPostForRelease", plugin, version, function( error, post ) {
+		if ( error ) {
+			return fn( error );
+		}
+
+		fn( null, wordpress.fieldMap.from( post, "post" ) );
+	});
+};
+
 client.post = {
 	fromRelease: function( data, fn ) {
 		var repo = data.repo,
@@ -56,11 +66,10 @@ client.post = {
 		return versions.length ? JSON.parse( versions[ 0 ].value ) : [];
 	},
 
-	addVersion: function( versions, newVersion ) {
+	parseVersions: function( versions ) {
 		var listed, latest;
 
 		listed = versions
-			.concat( newVersion )
 			.sort( semver.compare )
 			.reverse()
 			.filter(function( version ) {
@@ -84,6 +93,21 @@ client.post = {
 			listed: listed,
 			latest: latest
 		};
+	},
+
+	addVersion: function( versions, newVersion ) {
+		return this.parseVersions( versions.concat( newVersion ) );
+	},
+
+	removeVersion: function( versions, oldVersion ) {
+		var index = versions.indexOf( oldVersion );
+		if ( index !== -1 ) {
+			// Slice first to avoid modifying the original array
+			versions = versions.slice();
+			versions.splice( index, 1 );
+		}
+
+		return this.parseVersions( versions );
 	},
 
 	mergeCustomFields: function( existing, current ) {


### PR DESCRIPTION
This is primarily an attempt to fix #141 (accidental overwriting of a plugin) which was caused by a case sensitive check for plugin owners.

However, fixing this requires the ability to remove the offending plugin. Which means that #88 needs to be solved at least through an admin action. This is the harder part, and this PR really exists as a review for the code involved in this portion.

Once this lands, we can also fix #138 (spam plugins).